### PR TITLE
Use defaults for `autoRepair` and `autoUpgrade`

### DIFF
--- a/config/templates/basic/basic.cue
+++ b/config/templates/basic/basic.cue
@@ -57,10 +57,6 @@ _commonLabels: cluster: resource.metadata.name
 				clusterRef:       _commonRef
 				initialNodeCount: _nodes
 				location:         _location
-				management: {
-					autoRepair:  false
-					autoUpgrade: false
-				}
 				nodeConfig: {
 					diskSizeGb:  100
 					diskType:    "pd-standard"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -179,10 +179,6 @@ func TestClusterResources(t *testing.T) {
 					  "clusterRef": {
 						"name": "baz"
 					  },
-					  "management": {
-						"autoRepair": false,
-						"autoUpgrade": false
-					  },
 					  "nodeConfig": {
 						"metadata": {
 						  "disable-legacy-endpoints": "true"
@@ -410,10 +406,6 @@ func TestClusterResources(t *testing.T) {
 					  "initialNodeCount": 3,
 					  "clusterRef": {
 						"name": "bar"
-					  },
-					  "management": {
-						"autoRepair": false,
-						"autoUpgrade": false
 					  },
 					  "nodeConfig": {
 						"metadata": {


### PR DESCRIPTION
This is to fix #11.

These two features had been deliberately disable because they were
deemed to interfere with tests. GKE API no longer allows to disable
these features when using REGULAR release channel.

It maybe possible to disable this once cluster version would be set
statically, but that's not supported by the operator yet.

It's important to note that both of these features are concerting
the nodepool, not the control plane.

With regards to auto-updades, it maybe viable to define a maintenance
window that is outside of the expect test duration, but it's not a
very trivial solution to something that is currently only a hypothetical
problem.

With regards to auto-repairs, there is also no known practical issue
at present.